### PR TITLE
Fix incorrect pure attributes on mutating regex functions

### DIFF
--- a/include/regex.h
+++ b/include/regex.h
@@ -259,7 +259,7 @@ jstr_re_comp(jstr_re_ty *R preg, const char *R ptn, int cflags) JSTR_NOEXCEPT
 JSTR_NONNULL((1))
 JSTR_NONNULL((2))
 JSTR_ATTR_WARN_UNUSED
-JSTR_FUNC_PURE_MAY_NULL
+JSTR_FUNC_MAY_NULL
 JSTR_ATTR_NOTHROW
 jstr_re_ret_ty
 jstr_re_exec(const jstr_re_ty *R preg, const char *R s, size_t nmatch, regmatch_t *R pmatch, int eflags) JSTR_NOEXCEPT
@@ -278,7 +278,7 @@ jstr_re_exec(const jstr_re_ty *R preg, const char *R s, size_t nmatch, regmatch_
 ;
 #	endif
 
-JSTR_FUNC_PURE
+JSTR_FUNC
 jstr_re_ret_ty
 jstr_re_exec_len(const jstr_re_ty *R preg, const char *R s, size_t sz, size_t nmatch, regmatch_t *R pmatch, int eflags) JSTR_NOEXCEPT
 #	ifdef JSTR_IMPLEMENTATION
@@ -309,7 +309,7 @@ jstr_re_match(const jstr_re_ty *R preg, const char *R s, int eflags) JSTR_NOEXCE
 /* Search pattern in S.
  * Return return value of regexec.
  * Store offset of matched pattern in pmatch. */
-JSTR_FUNC_PURE
+JSTR_FUNC
 jstr_re_ret_ty
 jstr_re_search(const jstr_re_ty *R preg, const char *R s, regmatch_t *R pmatch, int eflags) JSTR_NOEXCEPT
 #	ifdef JSTR_IMPLEMENTATION

--- a/tests/test-regex-pure-bug.c
+++ b/tests/test-regex-pure-bug.c
@@ -1,0 +1,79 @@
+/* SPDX-License-Identifier: MIT */
+/* Copyright (c) 2023-2026 James Tirta Halim <tirtajames45 at gmail dot com> */
+
+#define __STDC_NO_VLA__ 1
+
+#include "test.h"
+#include "../include/regex.h"
+
+int
+main(int argc, char **argv)
+{
+	(void)argc;
+	(void)argv;
+	START();
+	{
+		jstr_re_ty preg;
+		assert(!jstr_re_chkcomp(jstr_re_comp(&preg, "a", 0)));
+		regmatch_t pmatch;
+		const char *s = "aaa";
+		size_t sz = 3;
+
+		/* Under -O2 with LTO, GCC could assume that pmatch is unchanged by a pure-attributed call. */
+		pmatch.rm_so = -1;
+		pmatch.rm_eo = -1;
+		jstr_re_ret_ty ret1 = jstr_re_exec_len(&preg, s, sz, 1, &pmatch, 0);
+		assert(ret1 == JSTR_RE_RET_NOERROR);
+		assert(pmatch.rm_so == 0);
+
+		pmatch.rm_so = -5;
+		pmatch.rm_eo = -5;
+		jstr_re_ret_ty ret2 = jstr_re_exec_len(&preg, s, sz, 1, &pmatch, 0);
+		assert(ret2 == JSTR_RE_RET_NOERROR);
+		assert(pmatch.rm_so == 0);
+
+		jstr_re_free(&preg);
+	}
+	{
+		jstr_re_ty preg;
+		assert(!jstr_re_chkcomp(jstr_re_comp(&preg, "a", 0)));
+		regmatch_t pmatch;
+		const char *s = "aaa";
+
+		pmatch.rm_so = -1;
+		pmatch.rm_eo = -1;
+		jstr_re_ret_ty ret1 = jstr_re_exec(&preg, s, 1, &pmatch, 0);
+		assert(ret1 == JSTR_RE_RET_NOERROR);
+		assert(pmatch.rm_so == 0);
+
+		pmatch.rm_so = -5;
+		pmatch.rm_eo = -5;
+		jstr_re_ret_ty ret2 = jstr_re_exec(&preg, s, 1, &pmatch, 0);
+		assert(ret2 == JSTR_RE_RET_NOERROR);
+		assert(pmatch.rm_so == 0);
+
+		jstr_re_free(&preg);
+	}
+	{
+		jstr_re_ty preg;
+		assert(!jstr_re_chkcomp(jstr_re_comp(&preg, "a", 0)));
+		regmatch_t pmatch;
+		const char *s = "aaa";
+
+		pmatch.rm_so = -1;
+		pmatch.rm_eo = -1;
+		jstr_re_ret_ty ret1 = jstr_re_search(&preg, s, &pmatch, 0);
+		assert(ret1 == JSTR_RE_RET_NOERROR);
+		assert(pmatch.rm_so == 0);
+
+		pmatch.rm_so = -5;
+		pmatch.rm_eo = -5;
+		jstr_re_ret_ty ret2 = jstr_re_search(&preg, s, &pmatch, 0);
+		assert(ret2 == JSTR_RE_RET_NOERROR);
+		assert(pmatch.rm_so == 0);
+
+		jstr_re_free(&preg);
+	}
+	SUCCESS();
+	return 0;
+}


### PR DESCRIPTION
This PR corrects wrong pure attributes on `jstr_re_exec`, `jstr_re_exec_len`, and `jstr_re_search` which mutate their output pointer argument, and adds a regression test ensuring these functions are not incorrectly optimized away under `-O2`.

---
*PR created automatically by Jules for task [11262561634874116778](https://jules.google.com/task/11262561634874116778) started by @IAKOBVS*